### PR TITLE
Ensure environment variables are not world-readable for systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ camo Cookbook Changelog
 ==========================
 This file is used to list changes made in each version of the camo cookbook.
 
+v0.9.4 (2018-11-06)
+-------------------
+- Ensure environment variables are not world-readable for systemd
+
 v0.9.3 (2016-10-30)
 -------------------
 - update rspec tests to match v0.9.2 changes

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Configures camo - a small http proxy to simplify routing images thr
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/svanzoest-cookbooks/camo/issues'
 source_url 'https://github.com/svanzoest-cookbooks/camo/'
-version '0.9.3'
+version '0.9.4'
 supports 'debian', '>= 7.0'
 supports 'ubuntu', '>= 12.04'
 supports 'centos', '>= 6.6'

--- a/recipes/_init_systemd.rb
+++ b/recipes/_init_systemd.rb
@@ -19,7 +19,7 @@
 
 template "#{node['camo']['systemd']['env_path']}/camo" do
   source 'camo.env.erb'
-  mode '0644'
+  mode '0640'
   owner 'root'
   group 'root'
   notifies :restart, 'service[camo]'


### PR DESCRIPTION
The file containing environmental variables for the systemd camo service should not be set to be world-readable. This sets the file to `640` instead of `644`.

The purpose of this PR is to prevent all users on a system from being able to read the `CAMO_KEY` secret. 